### PR TITLE
Update angular-country-select.js

### DIFF
--- a/angular-country-select.js
+++ b/angular-country-select.js
@@ -10,7 +10,7 @@ angular.module('angular-country-select', [])
         });
         scope.$watch(attrs.ngModel, function(newValue, oldValue) {
           if (newValue) {
-            elem.select2('val', newValue);
+            elem.select2.val(newValue);
           }
         });
       }

--- a/angular-country-select.js
+++ b/angular-country-select.js
@@ -10,7 +10,7 @@ angular.module('angular-country-select', [])
         });
         scope.$watch(attrs.ngModel, function(newValue, oldValue) {
           if (newValue) {
-            elem.select2.val(newValue);
+            $(elem).val(newValue).trigger("change");
           }
         });
       }


### PR DESCRIPTION
Method select2('val' is deprecated in version 4.0 https://select2.org/upgrading/migrating-from-35#select2-val